### PR TITLE
LPS-88224 - fixed shallow copy in layout staging clone methods

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutSetStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutSetStagingHandler.java
@@ -120,7 +120,7 @@ public class LayoutSetStagingHandler
 		return ProxyUtil.newProxyInstance(
 			PortalClassLoaderUtil.getClassLoader(),
 			new Class<?>[] {LayoutSet.class, ModelWrapper.class},
-			new LayoutSetStagingHandler(_layoutSet));
+			new LayoutSetStagingHandler((LayoutSet)_layoutSet.clone()));
 	}
 
 	private LayoutSetBranch _getLayoutSetBranch(LayoutSet layoutSet)

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
@@ -144,7 +144,9 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 		return ProxyUtil.newProxyInstance(
 			PortalClassLoaderUtil.getClassLoader(),
 			new Class<?>[] {Layout.class},
-			new LayoutStagingHandler(_layout, _layoutRevision));
+			new LayoutStagingHandler(
+				(Layout)_layout.clone(),
+				(LayoutRevision)_layoutRevision.clone()));
 	}
 
 	private LayoutRevision _getLayoutRevision(


### PR DESCRIPTION
Relevant Tickets - 
https://issues.liferay.com/browse/LPS-88224

The clone methods call a constructor, which would do a shallow copy of the Layout/LayoutRevision/LayoutSet objects. Added a .clone() to the parameters passed to the Layouts to deep copy.